### PR TITLE
Better builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,19 @@
-NAME := slack-deploy-command
+PROJECT := slack-deploy-command
 SOURCES := $(shell find . -name '*.go')
+
+VERSION := 1.0.0
+GIT_REVISION := $$(git rev-parse HEAD | cut -c -6)
+GOVERSION := $(shell go version)
+BUILDDATE := $(shell date -u +"%B %d, %Y")
+BUILDER := $(shell echo "`git config user.name` <`git config user.email`>")
+LDFLAGS := -X 'main.version=$(VERSION)' \
+           -X 'main.buildDate=$(BUILDDATE)' \
+           -X 'main.builder=$(BUILDER)' \
+           -X 'main.buildRev=$(GIT_REVISION)' \
+           -X 'main.buildGoVersion=$(GOVERSION)'
+
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
 
 PACKAGES := $$(go list ./... | grep -v /vendor/ | grep -v /cmd/)
 test:
@@ -8,20 +22,22 @@ test:
 build: slack-deploy-command
 
 slack-deploy-command: $(SOURCES)
-	GOGC=off GOOS=linux GOARCH=amd64 go build -o $(NAME)
+	GOGC=off GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags "$(LDFLAGS)" -o $(PROJECT)
 
 compress:
 ifeq (, $(shell command -v upx 2>/dev/null))
 	@echo "upx not found in PATH, proceeding with unpacked binary"
 else
-	upx -q $(NAME)
+	upx -q $(PROJECT)
 endif
 
 all: test build
 .DEFAULT_GOAL := all
 
+container: OS = linux
+container: ARCH = amd64
 container: all compress
-	docker build -t $(NAME) .
+	docker build -t $(PROJECT) .
 
 clean:
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ container: all compress
 clean:
 	go clean
 
-.PHONY: 
+.PHONY: test build slack-deploy-command compress all container clean

--- a/main.go
+++ b/main.go
@@ -27,22 +27,35 @@ var (
 	builder        = "n/a"
 
 	args struct {
-		host string
-		port int
+		host         string
+		port         int
+		printVersion bool
 	}
 )
 
 func init() {
+	flag.BoolVar(&args.printVersion, "version", false, "Print version and exit")
 	flag.StringVar(&args.host, "h", DefaultHost, "Host or address to listen on")
 	flag.IntVar(&args.port, "p", DefaultPort, "Port to listen on")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\nOptions:\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\nOptions:\n", binPath)
 		flag.PrintDefaults()
 	}
 }
 
+func printVersion() {
+	fmt.Printf("%s v%s (rev %s)\n", binPath, version, buildRev)
+	fmt.Printf("Built with %s on %s by %s\n\n", buildGoVersion, buildDate, builder)
+	fmt.Println("Found a bug? Got an idea? Open an issue on https://github.com/andrewslotin/slack-deploy-command\nContributions are welcome!")
+	os.Exit(0)
+}
+
 func main() {
 	flag.Parse()
+
+	if args.printVersion {
+		printVersion()
+	}
 
 	slackToken := os.Getenv("SLACK_TOKEN")
 	if slackToken == "" {

--- a/main.go
+++ b/main.go
@@ -18,10 +18,19 @@ const (
 	DefaultPort = 8081
 )
 
-var args struct {
-	host string
-	port int
-}
+var (
+	binPath        = os.Args[0]
+	version        = "n/a"
+	buildDate      = "n/a"
+	buildRev       = "n/a"
+	buildGoVersion = "n/a"
+	builder        = "n/a"
+
+	args struct {
+		host string
+		port int
+	}
+)
 
 func init() {
 	flag.StringVar(&args.host, "h", DefaultHost, "Host or address to listen on")


### PR DESCRIPTION
- Improved and cleaned up Makefile targets
- Inject build info (date, builder, Go version, etc.) on compile time
- Added `--version` option
