### PR TITLE
Markdown support

### DIFF
--- a/server/response_builder.go
+++ b/server/response_builder.go
@@ -75,6 +75,7 @@ func (b *ResponseBuilder) DeployAnnouncement(user slack.User, subject string) *s
 			Title:      fmt.Sprintf("PR #%d: %s", pr.Number, slack.EscapeMessage(pr.Title)),
 			TitleLink:  pr.URL,
 			Text:       pr.Body,
+			Markdown:   true,
 		})
 	}
 

--- a/slack/attachment.go
+++ b/slack/attachment.go
@@ -1,8 +1,59 @@
 package slack
 
+import "encoding/json"
+
 type Attachment struct {
-	AuthorName string `json:"author_name,omitempty"`
-	Title      string `json:"title"`
-	TitleLink  string `json:"title_link,omitempty"`
-	Text       string `json:"text,omitempty"`
+	AuthorName string
+	Title      string
+	TitleLink  string
+	Text       string
+	Markdown   bool
+}
+
+type internalAttachment struct {
+	AuthorName *string  `json:"author_name,omitempty"`
+	Title      *string  `json:"title"`
+	TitleLink  *string  `json:"title_link,omitempty"`
+	Text       *string  `json:"text,omitempty"`
+	MarkdownIn []string `json:"mrkdwn_in"`
+}
+
+func (a Attachment) MarshalJSON() ([]byte, error) {
+	v := internalAttachment{
+		AuthorName: &a.AuthorName,
+		Title:      &a.Title,
+		TitleLink:  &a.TitleLink,
+		Text:       &a.Text,
+	}
+
+	if a.Markdown {
+		v.MarkdownIn = []string{"text"}
+	}
+
+	return json.Marshal(v)
+}
+
+func (a *Attachment) UnmarshalJSON(data []byte) error {
+	if a == nil {
+		*a = Attachment{}
+	}
+
+	v := internalAttachment{
+		AuthorName: &a.AuthorName,
+		Title:      &a.Title,
+		TitleLink:  &a.TitleLink,
+		Text:       &a.Text,
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	for _, field := range v.MarkdownIn {
+		if field == "text" {
+			a.Markdown = true
+			break
+		}
+	}
+
+	return nil
 }

--- a/slack/attachment_test.go
+++ b/slack/attachment_test.go
@@ -1,0 +1,79 @@
+package slack_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/andrewslotin/slack-deploy-command/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttachment_MarshalJSON(t *testing.T) {
+	attachment := sampleAttachment()
+
+	data, err := json.Marshal(attachment)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m), string(data))
+
+	assert.Equal(t, attachment.AuthorName, m["author_name"])
+	assert.Equal(t, attachment.Title, m["title"])
+	assert.Equal(t, attachment.TitleLink, m["title_link"])
+	assert.Equal(t, attachment.Text, m["text"])
+	assert.Nil(t, m["mrkdwn_in"])
+}
+
+func TestAttachment_MarshalJSON_Markdown(t *testing.T) {
+	attachment := sampleAttachment()
+	attachment.Markdown = true
+
+	data, err := json.Marshal(attachment)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m), string(data))
+
+	assert.Equal(t, attachment.AuthorName, m["author_name"])
+	assert.Equal(t, attachment.Title, m["title"])
+	assert.Equal(t, attachment.TitleLink, m["title_link"])
+	assert.Equal(t, attachment.Text, m["text"])
+	assert.Equal(t, []interface{}{"text"}, m["mrkdwn_in"])
+}
+
+func TestAttachment_UnmarshalJSON(t *testing.T) {
+	attachment := sampleAttachment()
+	attachment.Markdown = true
+
+	data, err := json.Marshal(attachment)
+	require.NoError(t, err)
+
+	var unmarshaledAttachment slack.Attachment
+	require.NoError(t, json.Unmarshal(data, &unmarshaledAttachment), string(data))
+	assert.Equal(t, attachment, unmarshaledAttachment)
+}
+
+func TestAttachment_UnmarshalJSON_Pointer(t *testing.T) {
+	attachment := sampleAttachment()
+	attachment.Markdown = true
+
+	data, err := json.Marshal(attachment)
+	require.NoError(t, err)
+
+	var unmarshaledAttachment slack.Attachment
+	require.NoError(t, json.Unmarshal(data, &unmarshaledAttachment), string(data))
+
+	if assert.NotNil(t, unmarshaledAttachment) {
+		assert.Equal(t, attachment, unmarshaledAttachment)
+	}
+}
+
+func sampleAttachment() slack.Attachment {
+	return slack.Attachment{
+		AuthorName: "test user",
+		Title:      "test title",
+		TitleLink:  "http://test.com/",
+		Text:       "test body",
+	}
+}


### PR DESCRIPTION
Tell Slack to render GitHub issue description in attachments as Markdown.
