### PR TITLE
Deploy dashboard

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,0 +1,136 @@
+package bot
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/andrewslotin/slack-deploy-command/deploy"
+	"github.com/andrewslotin/slack-deploy-command/github"
+	"github.com/andrewslotin/slack-deploy-command/slack"
+)
+
+type DeployEventHandler interface {
+	DeployStarted(channelID string)
+	DeployCompleted(channelID string)
+}
+
+type Bot struct {
+	slackToken string
+	deploys    *deploy.ChannelDeploys
+	responses  *ResponseBuilder
+
+	deployEventHandlers []DeployEventHandler
+}
+
+func New(slackToken, githubToken string, store deploy.Store) *Bot {
+	return &Bot{
+		slackToken: slackToken,
+		deploys:    deploy.NewChannelDeploys(store),
+		responses:  NewResponseBuilder(github.NewClient(githubToken, nil)),
+	}
+}
+
+func (b *Bot) AddDeployEventHandler(h DeployEventHandler) {
+	b.deployEventHandlers = append(b.deployEventHandlers, h)
+}
+
+func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Only POST requests are supported", http.StatusBadRequest)
+		return
+	}
+
+	if r.PostFormValue("token") != b.slackToken {
+		http.Error(w, "Invalid token", http.StatusForbidden)
+		return
+	}
+
+	if cmd := r.PostFormValue("command"); cmd != "/deploy" {
+		sendImmediateResponse(w, b.responses.ErrorMessage(cmd, errors.New("not supported")))
+		return
+	}
+
+	channelID := r.PostFormValue("channel_id")
+	user := slack.User{
+		ID:   r.PostFormValue("user_id"),
+		Name: r.PostFormValue("user_name"),
+	}
+
+	switch subject := r.PostFormValue("text"); subject {
+	case "", "help":
+		sendImmediateResponse(w, b.responses.HelpMessage())
+	case "status":
+		d, ok := b.deploys.Current(channelID)
+		if !ok {
+			sendImmediateResponse(w, b.responses.NoRunningDeploysMessage())
+			return
+		}
+
+		sendImmediateResponse(w, b.responses.DeployStatusMessage(d))
+	case "done":
+		d, ok := b.deploys.Finish(channelID)
+		if !ok {
+			sendImmediateResponse(w, b.responses.NoRunningDeploysMessage())
+			return
+		}
+
+		if d.User.ID == user.ID {
+			go sendDelayedResponse(w, r, b.responses.DeployDoneAnnouncement(user))
+		} else {
+			go sendDelayedResponse(w, r, b.responses.DeployInterruptedAnnouncement(d, user))
+		}
+
+		for _, h := range b.deployEventHandlers {
+			go h.DeployCompleted(channelID)
+		}
+	default:
+		d, ok := b.deploys.Start(channelID, deploy.New(user, subject))
+		if !ok {
+			sendImmediateResponse(w, b.responses.DeployInProgressMessage(d))
+			return
+		}
+
+		w.Write(nil)
+
+		go sendDelayedResponse(w, r, b.responses.DeployAnnouncement(user, subject))
+		for _, h := range b.deployEventHandlers {
+			go h.DeployStarted(channelID)
+		}
+	}
+}
+
+func sendImmediateResponse(w http.ResponseWriter, response *slack.Response) {
+	body, err := json.Marshal(response)
+	if err != nil {
+		log.Printf("failed to respond to user with %q (%s)", response.Text, err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(body)
+}
+
+func sendDelayedResponse(w http.ResponseWriter, req *http.Request, response *slack.Response) {
+	responseURL := req.PostFormValue("response_url")
+	if responseURL == "" {
+		log.Printf("cannot send delayed response to a without without response_url")
+		return
+	}
+
+	body, err := json.Marshal(response)
+	if err != nil {
+		log.Printf("failed to respond in channel with %s (%s)", response.Text, err)
+		return
+	}
+
+	slackResponse, err := http.Post(responseURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		log.Printf("failed to sent in_channel response (%s)", err)
+		return
+	}
+	slackResponse.Body.Close()
+}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -86,6 +86,8 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, h := range b.deployEventHandlers {
 			go h.DeployCompleted(channelID)
 		}
+	case "history":
+		sendImmediateResponse(w, b.responses.DeployHistoryLink(r.Host, channelID))
 	default:
 		d, ok := b.deploys.Start(channelID, deploy.New(user, subject))
 		if !ok {

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
@@ -84,6 +85,10 @@ func (b *ResponseBuilder) DeployAnnouncement(user slack.User, subject string) *s
 
 func (b *ResponseBuilder) DeployDoneAnnouncement(user slack.User) *slack.Response {
 	return newAnnouncement(fmt.Sprintf(deployDoneMessage, user))
+}
+
+func (*ResponseBuilder) DeployHistoryLink(host, channelID string) *slack.Response {
+	return newUserMessage("https://" + host + "/?channel_id=" + url.QueryEscape(channelID))
 }
 
 func newUserMessage(s string) *slack.Response {

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
@@ -88,6 +89,7 @@ func (b *ResponseBuilder) DeployDoneAnnouncement(user slack.User) *slack.Respons
 }
 
 func (*ResponseBuilder) DeployHistoryLink(host, channelID string) *slack.Response {
+	host = strings.TrimSuffix(strings.TrimSuffix(host, ":80"), ":443")
 	return newUserMessage("https://" + host + "/?channel_id=" + url.QueryEscape(channelID))
 }
 

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -1,4 +1,4 @@
-package server
+package bot
 
 import (
 	"fmt"

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -17,7 +17,8 @@ const (
 /deploy help — print help (this message)
 /deploy <subject> — announce deploy of <subject> in channel
 /deploy status — show deploy status in channel
-/deploy done — finish deploy`
+/deploy done — finish deploy
+/deploy history — get a link to history of deploys in this channel`
 	errorMessage              = "`%s` returned an error %s"
 	noRunningDeploysMessage   = "No one is deploying at the moment"
 	deployStatusMessage       = "%s is deploying %s since %s"
@@ -25,6 +26,7 @@ const (
 	deployDoneMessage         = "%s done deploying"
 	deployInterruptedMessage  = "%s has finished the deploy started by %s"
 	deployAnnouncementMessage = "%s is about to deploy %s"
+	deployHistoryLinkMessage  = "Click <https://%s/?channel_id=%s|here> to see deploy history in this channel"
 )
 
 type ResponseBuilder struct {
@@ -90,7 +92,8 @@ func (b *ResponseBuilder) DeployDoneAnnouncement(user slack.User) *slack.Respons
 
 func (*ResponseBuilder) DeployHistoryLink(host, channelID string) *slack.Response {
 	host = strings.TrimSuffix(strings.TrimSuffix(host, ":80"), ":443")
-	return newUserMessage("https://" + host + "/?channel_id=" + url.QueryEscape(channelID))
+
+	return newUserMessage(fmt.Sprintf(deployHistoryLinkMessage, host, url.QueryEscape(channelID)))
 }
 
 func newUserMessage(s string) *slack.Response {

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -1,4 +1,4 @@
-package server_test
+package bot_test
 
 import (
 	"errors"
@@ -7,15 +7,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andrewslotin/slack-deploy-command/bot"
 	"github.com/andrewslotin/slack-deploy-command/deploy"
 	"github.com/andrewslotin/slack-deploy-command/github"
-	"github.com/andrewslotin/slack-deploy-command/server"
 	"github.com/andrewslotin/slack-deploy-command/slack"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestResponseBuilder_HelpMessage(t *testing.T) {
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.HelpMessage()
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
@@ -25,7 +25,7 @@ func TestResponseBuilder_HelpMessage(t *testing.T) {
 }
 
 func TestResponseBuilder_ErrorMessage(t *testing.T) {
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.ErrorMessage("/command do", errors.New("error message"))
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
@@ -34,7 +34,7 @@ func TestResponseBuilder_ErrorMessage(t *testing.T) {
 }
 
 func TestResponseBuilder_NoRunningDeploysMessage(t *testing.T) {
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.NoRunningDeploysMessage()
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
@@ -48,7 +48,7 @@ func TestResponseBuilder_DeployStatusMessage(t *testing.T) {
 		StartedAt: time.Now(),
 	}
 
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.DeployStatusMessage(d)
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
@@ -64,7 +64,7 @@ func TestResponseBuilder_DeployInProgressMessage(t *testing.T) {
 		StartedAt: time.Now(),
 	}
 
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.DeployInProgressMessage(d)
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
@@ -79,7 +79,7 @@ func TestResponseBuilder_DeployInterruptedAnnouncement(t *testing.T) {
 	}
 	user := slack.User{ID: "xyz456", Name: "user2"}
 
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.DeployInterruptedAnnouncement(d, user)
 
 	assert.Equal(t, slack.ResponseTypeInChannel, response.ResponseType)
@@ -103,7 +103,7 @@ func TestResponseBuilder_DeployAnnouncement(t *testing.T) {
 
 	user := slack.User{ID: "abc123", Name: "user1"}
 
-	b := server.NewResponseBuilder(githubClient)
+	b := bot.NewResponseBuilder(githubClient)
 	response := b.DeployAnnouncement(user, "user1/repo1#123 and user2/repo2#234")
 
 	assert.Equal(t, slack.ResponseTypeInChannel, response.ResponseType)
@@ -126,7 +126,7 @@ func TestResponseBuilder_DeployAnnouncement(t *testing.T) {
 func TestResponseBuilder_DeployDoneAnnouncement(t *testing.T) {
 	user := slack.User{ID: "abc123", Name: "user1"}
 
-	b := server.NewResponseBuilder(github.NewClient("", nil))
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
 	response := b.DeployDoneAnnouncement(user)
 
 	assert.Equal(t, slack.ResponseTypeInChannel, response.ResponseType)

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -133,6 +133,14 @@ func TestResponseBuilder_DeployDoneAnnouncement(t *testing.T) {
 	assert.Contains(t, response.Text, user.String())
 }
 
+func TestResponseBuilder_DeployHistoryLink(t *testing.T) {
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
+	response := b.DeployHistoryLink("www.example.com:8080", "abc 123")
+
+	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
+	assert.Contains(t, response.Text, "https://www.example.com:8080/?channel_id=abc+123")
+}
+
 func setupGitHubTestServer() (baseURL string, mux *http.ServeMux, teardownFn func()) {
 	mux = http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -141,6 +141,17 @@ func TestResponseBuilder_DeployHistoryLink(t *testing.T) {
 	assert.Contains(t, response.Text, "https://www.example.com:8080/?channel_id=abc+123")
 }
 
+func TestResponseBuilder_DeployHistoryLink_StandardPorts(t *testing.T) {
+	standardPorts := [...]string{"80", "443"}
+
+	b := bot.NewResponseBuilder(github.NewClient("", nil))
+
+	for _, port := range standardPorts {
+		response := b.DeployHistoryLink("www.example.com:"+port, "abc 123")
+		assert.Contains(t, response.Text, "https://www.example.com/?channel_id=abc+123", "port: %s", port)
+	}
+}
+
 func setupGitHubTestServer() (baseURL string, mux *http.ServeMux, teardownFn func()) {
 	mux = http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/bot/slack_topic_manager.go
+++ b/bot/slack_topic_manager.go
@@ -1,4 +1,4 @@
-package server
+package bot
 
 import (
 	"log"

--- a/bot/slack_topic_manager_test.go
+++ b/bot/slack_topic_manager_test.go
@@ -1,4 +1,4 @@
-package server_test
+package bot_test
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/andrewslotin/slack-deploy-command/server"
+	"github.com/andrewslotin/slack-deploy-command/bot"
 	"github.com/andrewslotin/slack-deploy-command/slack"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,15 +23,15 @@ func TestSlackTopicManager_DeployStarted_NoRunningDeploy(t *testing.T) {
 	defer teardown()
 
 	channel.ID = "CHANNELID1"
-	channel.Topic = "-=:poop:" + strings.Repeat(server.DeployDoneEmotion, 3) + ":poop:=-"
+	channel.Topic = "-=:poop:" + strings.Repeat(bot.DeployDoneEmotion, 3) + ":poop:=-"
 
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployStarted(channel.ID)
 
-	assert.Equal(t, "-=:poop:"+strings.Repeat(server.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
+	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
 }
 
 func TestSlackTopicManager_DeployStarted_NoTopicNotification(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSlackTopicManager_DeployStarted_NoTopicNotification(t *testing.T) {
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployStarted(channel.ID)
 
 	assert.Equal(t, "-=:poop:=-", channel.Topic)
@@ -55,15 +55,15 @@ func TestSlackTopicManager_DeployStarted_InProgress(t *testing.T) {
 	defer teardown()
 
 	channel.ID = "CHANNELID1"
-	channel.Topic = "-=:poop:" + strings.Repeat(server.DeployInProgressEmotion, 3) + ":poop:=-"
+	channel.Topic = "-=:poop:" + strings.Repeat(bot.DeployInProgressEmotion, 3) + ":poop:=-"
 
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployStarted(channel.ID)
 
-	assert.Equal(t, "-=:poop:"+strings.Repeat(server.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
+	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
 }
 
 func TestSlackTopicManager_DeployCompleted_InProgress(t *testing.T) {
@@ -71,15 +71,15 @@ func TestSlackTopicManager_DeployCompleted_InProgress(t *testing.T) {
 	defer teardown()
 
 	channel.ID = "CHANNELID1"
-	channel.Topic = "-=:poop:" + strings.Repeat(server.DeployInProgressEmotion, 3) + ":poop:=-"
+	channel.Topic = "-=:poop:" + strings.Repeat(bot.DeployInProgressEmotion, 3) + ":poop:=-"
 
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployCompleted(channel.ID)
 
-	assert.Equal(t, "-=:poop:"+strings.Repeat(server.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
+	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
 }
 
 func TestSlackTopicManager_DeployCompleted_NoTopicNotification(t *testing.T) {
@@ -92,7 +92,7 @@ func TestSlackTopicManager_DeployCompleted_NoTopicNotification(t *testing.T) {
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployCompleted(channel.ID)
 
 	assert.Equal(t, "-=:poop:=-", channel.Topic)
@@ -103,15 +103,15 @@ func TestSlackTopicManager_DeployCompleted_NoRunningDeploy(t *testing.T) {
 	defer teardown()
 
 	channel.ID = "CHANNELID1"
-	channel.Topic = "-=:poop:" + strings.Repeat(server.DeployDoneEmotion, 3) + ":poop:=-"
+	channel.Topic = "-=:poop:" + strings.Repeat(bot.DeployDoneEmotion, 3) + ":poop:=-"
 
 	webAPI := slack.NewWebAPI(webAPIToken, nil)
 	webAPI.BaseURL = baseURL
 
-	mgr := server.NewSlackTopicManager(webAPI)
+	mgr := bot.NewSlackTopicManager(webAPI)
 	mgr.DeployCompleted(channel.ID)
 
-	assert.Equal(t, "-=:poop:"+strings.Repeat(server.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
+	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
 }
 
 func setupSlackWebAPITestServer(t *testing.T) (baseURL string, channel *SlackChannel, teardownFn func()) {

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -1,0 +1,51 @@
+package dashboard
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/andrewslotin/slack-deploy-command/deploy"
+)
+
+var dashboardTemplate = template.Must(
+	template.New("dashboard").
+		Funcs(template.FuncMap{
+			"ftime": func(t time.Time) string { return t.Format(time.RFC822) },
+		}).
+		Parse(strings.TrimSpace(`
+Deploy history
+--------------
+
+{{ range . -}}
+{{ if not .FinishedAt.IsZero -}}
+  * {{ .User.Name }} was deploying {{ .Subject }} since {{ .StartedAt | ftime }} until {{ .FinishedAt | ftime }}
+{{ else -}}
+  * {{ .User.Name }} is currently deploying {{ .Subject }} since {{ .StartedAt | ftime }}
+{{ end -}}
+{{ else -}}
+  No deploys in channel so far
+{{ end }}
+`)))
+
+type Dashboard struct {
+	repo deploy.Repository
+}
+
+func New(repo deploy.Repository) *Dashboard {
+	return &Dashboard{
+		repo: repo,
+	}
+}
+
+func (h *Dashboard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	channelID := r.FormValue("channel_id")
+	if channelID == "" {
+		http.Error(w, "Missing channel_id", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain")
+	dashboardTemplate.Execute(w, h.repo.All(channelID))
+}

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -1,0 +1,156 @@
+package dashboard_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/andrewslotin/slack-deploy-command/dashboard"
+	"github.com/andrewslotin/slack-deploy-command/deploy"
+	"github.com/andrewslotin/slack-deploy-command/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+	Test objects
+*/
+type repoMock struct {
+	mock.Mock
+}
+
+func (m repoMock) All(key string) []deploy.Deploy {
+	return m.Called(key).Get(0).([]deploy.Deploy)
+}
+
+/*
+	Tests
+*/
+
+func TestDashboard_OneDeploy(t *testing.T) {
+	url, mux, teardown := setup()
+	defer teardown()
+
+	d := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test deploy")
+	d.StartedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:28 CEST")
+	d.FinishedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:38 CEST")
+
+	var repo repoMock
+	repo.On("All", "key1").Return([]deploy.Deploy{d})
+
+	mux.Handle("/", dashboard.New(repo))
+
+	response, err := http.Get(url + "/?channel_id=key1")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/plain", response.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(response.Body)
+	response.Body.Close()
+	require.NoError(t, err)
+
+	expected := "" +
+		"Deploy history\n" +
+		"--------------\n" +
+		"\n" +
+		"* Test User was deploying Test deploy since 04 Aug 16 09:28 CEST until 04 Aug 16 09:38 CEST"
+
+	assert.Equal(t, expected, string(bytes.TrimSpace(body)))
+}
+
+func TestDashboard_MultipleDeploys(t *testing.T) {
+	url, mux, teardown := setup()
+	defer teardown()
+
+	d1 := deploy.New(slack.User{ID: "1", Name: "Test User"}, "First deploy")
+	d1.StartedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:28 CEST")
+	d1.FinishedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:38 CEST")
+
+	d2 := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Second deploy")
+	d2.StartedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:39 CEST")
+	d2.FinishedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:40 CEST")
+
+	d3 := deploy.New(slack.User{ID: "2", Name: "Another User"}, "Third deploy")
+	d3.StartedAt, _ = time.Parse(time.RFC822, "04 Aug 16 09:50 CEST")
+
+	var repo repoMock
+	repo.On("All", "key1").Return([]deploy.Deploy{d1, d2, d3})
+
+	mux.Handle("/", dashboard.New(repo))
+
+	response, err := http.Get(url + "/?channel_id=key1")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/plain", response.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(response.Body)
+	response.Body.Close()
+	require.NoError(t, err)
+
+	expected := "" +
+		"Deploy history\n" +
+		"--------------\n" +
+		"\n" +
+		"* Test User was deploying First deploy since 04 Aug 16 09:28 CEST until 04 Aug 16 09:38 CEST\n" +
+		"* Test User was deploying Second deploy since 04 Aug 16 09:39 CEST until 04 Aug 16 09:40 CEST\n" +
+		"* Another User is currently deploying Third deploy since 04 Aug 16 09:50 CEST"
+
+	assert.Equal(t, expected, string(bytes.TrimSpace(body)))
+}
+
+func TestDashboard_NoDeploys(t *testing.T) {
+	url, mux, teardown := setup()
+	defer teardown()
+
+	var repo repoMock
+	repo.On("All", "key1").Return([]deploy.Deploy(nil))
+
+	mux.Handle("/", dashboard.New(repo))
+
+	response, err := http.Get(url + "/?channel_id=key1")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/plain", response.Header.Get("Content-Type"))
+
+	body, err := ioutil.ReadAll(response.Body)
+	response.Body.Close()
+	require.NoError(t, err)
+
+	expected := "" +
+		"Deploy history\n" +
+		"--------------\n" +
+		"\n" +
+		"No deploys in channel so far"
+
+	assert.Equal(t, expected, string(bytes.TrimSpace(body)))
+}
+
+func TestDashboard_MissingChannelID(t *testing.T) {
+	url, mux, teardown := setup()
+	defer teardown()
+
+	var repo repoMock
+	repo.On("All", "key1").Return([]deploy.Deploy(nil))
+
+	mux.Handle("/", dashboard.New(repo))
+
+	response, err := http.Get(url + "/")
+	require.NoError(t, err)
+	response.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+}
+
+func setup() (url string, mux *http.ServeMux, teardownFn func()) {
+	mux = http.NewServeMux()
+	srv := httptest.NewServer(mux)
+
+	return srv.URL, mux, srv.Close
+}

--- a/deploy/bolt_db_store_test.go
+++ b/deploy/bolt_db_store_test.go
@@ -1,68 +1,56 @@
 package deploy_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
-	"github.com/andrewslotin/slack-deploy-command/slack"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-func TestBoltDBStore(t *testing.T) {
+func TestBoltDBStore_AsStore(t *testing.T) {
 	suite.Run(t, &StoreSuite{Setup: func() (store deploy.Store, teardownFn func(), err error) {
-		fd, err := ioutil.TempFile(os.TempDir(), "doppelganger")
+		path, err := tempDBFilePath()
 		if err != nil {
 			return nil, nil, err
 		}
-		fd.Close()
 
-		store, err = deploy.NewBoltDBStore(fd.Name())
+		teardownFn = func() { os.Remove(path) }
+
+		store, err = deploy.NewBoltDBStore(path)
 		if err != nil {
-			return nil, func() { os.Remove(fd.Name()) }, err
+			return nil, teardownFn, err
 		}
 
-		return store, func() { os.Remove(fd.Name()) }, nil
+		return store, teardownFn, nil
 	}})
 }
 
-func TestBoltDBStore_All(t *testing.T) {
+func TestBoltDBStore_AsRepository(t *testing.T) {
+	suite.Run(t, &RepositorySuite{Setup: func() (repo deploy.Repository, setFn func(string, deploy.Deploy), teardownFn func(), err error) {
+		path, err := tempDBFilePath()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		teardownFn = func() { os.Remove(path) }
+
+		r, err := deploy.NewBoltDBStore(path)
+		if err != nil {
+			return nil, nil, teardownFn, err
+		}
+
+		return r, r.Set, teardownFn, nil
+	}})
+}
+
+func tempDBFilePath() (string, error) {
 	fd, err := ioutil.TempFile(os.TempDir(), "doppelganger")
-	require.NoError(t, err)
+	if err != nil {
+		return "", err
+	}
 	fd.Close()
-	defer os.Remove(fd.Name())
 
-	store, err := deploy.NewBoltDBStore(fd.Name())
-	require.NoError(t, err)
-
-	now := time.Now()
-	key := "key1"
-	user := slack.User{ID: "1", Name: "User 1"}
-
-	var deploys []deploy.Deploy
-	for delta := -10 * time.Minute; delta < 0; delta += time.Minute {
-		d := deploy.New(user, fmt.Sprintf("Deploy from %s ago", delta))
-		d.StartedAt = now.Add(delta)
-		if delta+time.Minute < 0 {
-			d.FinishedAt = now.Add(delta + time.Minute)
-		}
-
-		store.Set("key1", d)
-		deploys = append(deploys, d)
-	}
-
-	allDeploys := store.All(key)
-	if assert.Len(t, allDeploys, len(deploys)) {
-		for i, d := range allDeploys {
-			assert.Equal(t, deploys[i].User, d.User)
-			assert.Equal(t, deploys[i].Subject, d.Subject)
-			assert.True(t, deploys[i].StartedAt.Equal(d.StartedAt), "expected %s, got %s", deploys[i].StartedAt, d.StartedAt)
-			assert.True(t, deploys[i].FinishedAt.Equal(d.FinishedAt), "expected %s, got %s", deploys[i].FinishedAt, d.FinishedAt)
-		}
-	}
+	return fd.Name(), nil
 }

--- a/deploy/bolt_db_store_test.go
+++ b/deploy/bolt_db_store_test.go
@@ -1,11 +1,16 @@
 package deploy_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
+	"github.com/andrewslotin/slack-deploy-command/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -24,4 +29,40 @@ func TestBoltDBStore(t *testing.T) {
 
 		return store, func() { os.Remove(fd.Name()) }, nil
 	}})
+}
+
+func TestBoltDBStore_All(t *testing.T) {
+	fd, err := ioutil.TempFile(os.TempDir(), "doppelganger")
+	require.NoError(t, err)
+	fd.Close()
+	defer os.Remove(fd.Name())
+
+	store, err := deploy.NewBoltDBStore(fd.Name())
+	require.NoError(t, err)
+
+	now := time.Now()
+	key := "key1"
+	user := slack.User{ID: "1", Name: "User 1"}
+
+	var deploys []deploy.Deploy
+	for delta := -10 * time.Minute; delta < 0; delta += time.Minute {
+		d := deploy.New(user, fmt.Sprintf("Deploy from %s ago", delta))
+		d.StartedAt = now.Add(delta)
+		if delta+time.Minute < 0 {
+			d.FinishedAt = now.Add(delta + time.Minute)
+		}
+
+		store.Set("key1", d)
+		deploys = append(deploys, d)
+	}
+
+	allDeploys := store.All(key)
+	if assert.Len(t, allDeploys, len(deploys)) {
+		for i, d := range allDeploys {
+			assert.Equal(t, deploys[i].User, d.User)
+			assert.Equal(t, deploys[i].Subject, d.Subject)
+			assert.True(t, deploys[i].StartedAt.Equal(d.StartedAt), "expected %s, got %s", deploys[i].StartedAt, d.StartedAt)
+			assert.True(t, deploys[i].FinishedAt.Equal(d.FinishedAt), "expected %s, got %s", deploys[i].FinishedAt, d.FinishedAt)
+		}
+	}
 }

--- a/deploy/in_memory_store.go
+++ b/deploy/in_memory_store.go
@@ -35,3 +35,12 @@ func (s *InMemoryStore) Set(key string, d Deploy) {
 	}
 	s.mu.Unlock()
 }
+
+func (s *InMemoryStore) All(key string) []Deploy {
+	deploys := make([]Deploy, len(s.m[key]))
+	s.mu.RLock()
+	copy(deploys, s.m[key])
+	s.mu.RUnlock()
+
+	return deploys
+}

--- a/deploy/in_memory_store_test.go
+++ b/deploy/in_memory_store_test.go
@@ -1,48 +1,21 @@
 package deploy_test
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
-	"github.com/andrewslotin/slack-deploy-command/slack"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
-func TestInMemoryStore(t *testing.T) {
+func TestInMemoryStore_AsStore(t *testing.T) {
 	suite.Run(t, &StoreSuite{Setup: func() (store deploy.Store, teardownFn func(), err error) {
 		return deploy.NewInMemoryStore(), nil, nil
 	}})
 }
 
-func TestBoltDBStore_All(t *testing.T) {
-	store := deploy.NewInMemoryStore()
-
-	now := time.Now()
-	key := "key1"
-	user := slack.User{ID: "1", Name: "User 1"}
-
-	var deploys []deploy.Deploy
-	for delta := -10 * time.Minute; delta < 0; delta += time.Minute {
-		d := deploy.New(user, fmt.Sprintf("Deploy from %s ago", delta))
-		d.StartedAt = now.Add(delta)
-		if delta+time.Minute < 0 {
-			d.FinishedAt = now.Add(delta + time.Minute)
-		}
-
-		store.Set("key1", d)
-		deploys = append(deploys, d)
-	}
-
-	allDeploys := store.All(key)
-	if assert.Len(t, allDeploys, len(deploys)) {
-		for i, d := range allDeploys {
-			assert.Equal(t, deploys[i].User, d.User)
-			assert.Equal(t, deploys[i].Subject, d.Subject)
-			assert.True(t, deploys[i].StartedAt.Equal(d.StartedAt), "expected %s, got %s", deploys[i].StartedAt, d.StartedAt)
-			assert.True(t, deploys[i].FinishedAt.Equal(d.FinishedAt), "expected %s, got %s", deploys[i].FinishedAt, d.FinishedAt)
-		}
-	}
+func TestInMemoryStore_AsRepository(t *testing.T) {
+	suite.Run(t, &RepositorySuite{Setup: func() (repo deploy.Repository, setFn func(string, deploy.Deploy), teardownFn func(), err error) {
+		r := deploy.NewInMemoryStore()
+		return r, r.Set, nil, nil
+	}})
 }

--- a/deploy/in_memory_store_test.go
+++ b/deploy/in_memory_store_test.go
@@ -1,9 +1,13 @@
 package deploy_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/andrewslotin/slack-deploy-command/deploy"
+	"github.com/andrewslotin/slack-deploy-command/slack"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -11,4 +15,34 @@ func TestInMemoryStore(t *testing.T) {
 	suite.Run(t, &StoreSuite{Setup: func() (store deploy.Store, teardownFn func(), err error) {
 		return deploy.NewInMemoryStore(), nil, nil
 	}})
+}
+
+func TestBoltDBStore_All(t *testing.T) {
+	store := deploy.NewInMemoryStore()
+
+	now := time.Now()
+	key := "key1"
+	user := slack.User{ID: "1", Name: "User 1"}
+
+	var deploys []deploy.Deploy
+	for delta := -10 * time.Minute; delta < 0; delta += time.Minute {
+		d := deploy.New(user, fmt.Sprintf("Deploy from %s ago", delta))
+		d.StartedAt = now.Add(delta)
+		if delta+time.Minute < 0 {
+			d.FinishedAt = now.Add(delta + time.Minute)
+		}
+
+		store.Set("key1", d)
+		deploys = append(deploys, d)
+	}
+
+	allDeploys := store.All(key)
+	if assert.Len(t, allDeploys, len(deploys)) {
+		for i, d := range allDeploys {
+			assert.Equal(t, deploys[i].User, d.User)
+			assert.Equal(t, deploys[i].Subject, d.Subject)
+			assert.True(t, deploys[i].StartedAt.Equal(d.StartedAt), "expected %s, got %s", deploys[i].StartedAt, d.StartedAt)
+			assert.True(t, deploys[i].FinishedAt.Equal(d.FinishedAt), "expected %s, got %s", deploys[i].FinishedAt, d.FinishedAt)
+		}
+	}
 }

--- a/deploy/repository.go
+++ b/deploy/repository.go
@@ -1,0 +1,5 @@
+package deploy
+
+type Repository interface {
+	All(key string) []Deploy
+}

--- a/deploy/repository_test.go
+++ b/deploy/repository_test.go
@@ -1,0 +1,51 @@
+package deploy_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/andrewslotin/slack-deploy-command/deploy"
+	"github.com/andrewslotin/slack-deploy-command/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type RepositorySuite struct {
+	suite.Suite
+	Setup func() (deploy.Repository, func(string, deploy.Deploy), func(), error)
+}
+
+func (suite *RepositorySuite) TestAll() {
+	repo, storeSet, teardown, err := suite.Setup()
+	if teardown != nil {
+		defer teardown()
+	}
+	require.NoError(suite.T(), err)
+
+	now := time.Now()
+	key := "key1"
+	user := slack.User{ID: "1", Name: "User 1"}
+
+	var deploys []deploy.Deploy
+	for delta := -10 * time.Minute; delta < 0; delta += time.Minute {
+		d := deploy.New(user, fmt.Sprintf("Deploy from %s ago", delta))
+		d.StartedAt = now.Add(delta)
+		if delta+time.Minute < 0 {
+			d.FinishedAt = now.Add(delta + time.Minute)
+		}
+
+		storeSet("key1", d)
+		deploys = append(deploys, d)
+	}
+
+	allDeploys := repo.All(key)
+	if assert.Len(suite.T(), allDeploys, len(deploys)) {
+		for i, d := range allDeploys {
+			assert.Equal(suite.T(), deploys[i].User, d.User)
+			assert.Equal(suite.T(), deploys[i].Subject, d.Subject)
+			assert.True(suite.T(), deploys[i].StartedAt.Equal(d.StartedAt), "expected %s, got %s", deploys[i].StartedAt, d.StartedAt)
+			assert.True(suite.T(), deploys[i].FinishedAt.Equal(d.FinishedAt), "expected %s, got %s", deploys[i].FinishedAt, d.FinishedAt)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -85,8 +86,11 @@ func main() {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}
 
+	mux := http.NewServeMux()
+	mux.Handle("/", slackBot)
+
 	srv := server.New(args.host, args.port)
-	if err := srv.Start(slackBot); err != nil {
+	if err := srv.Start(mux); err != nil {
 		log.Fatal(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}
 
-	if err := srv.Start(); err != nil {
+	if err := srv.Start(srv); err != nil {
 		log.Fatal(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}
 
-	srv := server.New(args.host, args.port, slackToken, githubToken, store)
+	srv := server.New(args.host, args.port)
 	if err := srv.Start(slackBot); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/andrewslotin/slack-deploy-command/bot"
 	"github.com/andrewslotin/slack-deploy-command/deploy"
 	"github.com/andrewslotin/slack-deploy-command/server"
 	"github.com/andrewslotin/slack-deploy-command/slack"
@@ -79,7 +80,7 @@ func main() {
 
 	if slackWebAPIToken := os.Getenv("SLACK_WEBAPI_TOKEN"); slackWebAPIToken != "" {
 		api := slack.NewWebAPI(slackWebAPIToken, nil)
-		srv.AddDeployEventHandler(server.NewSlackTopicManager(api))
+		srv.AddDeployEventHandler(bot.NewSlackTopicManager(api))
 	} else {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", slackBot)
+	mux.Handle("/deploy", slackBot)
 
 	srv := server.New(args.host, args.port)
 	if err := srv.Start(mux); err != nil {

--- a/main.go
+++ b/main.go
@@ -76,16 +76,17 @@ func main() {
 		log.Fatalf("failed to open deploy DB: %s", err)
 	}
 
-	srv := server.New(args.host, args.port, slackToken, githubToken, store)
+	slackBot := bot.New(slackToken, githubToken, store)
 
 	if slackWebAPIToken := os.Getenv("SLACK_WEBAPI_TOKEN"); slackWebAPIToken != "" {
 		api := slack.NewWebAPI(slackWebAPIToken, nil)
-		srv.AddDeployEventHandler(bot.NewSlackTopicManager(api))
+		slackBot.AddDeployEventHandler(bot.NewSlackTopicManager(api))
 	} else {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}
 
-	if err := srv.Start(srv); err != nil {
+	srv := server.New(args.host, args.port, slackToken, githubToken, store)
+	if err := srv.Start(slackBot); err != nil {
 		log.Fatal(err)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/andrewslotin/slack-deploy-command/bot"
 	"github.com/andrewslotin/slack-deploy-command/deploy"
 	"github.com/andrewslotin/slack-deploy-command/github"
 	"github.com/andrewslotin/slack-deploy-command/slack"
@@ -25,7 +26,7 @@ type Server struct {
 	listener   net.Listener
 	slackToken string
 	deploys    *deploy.ChannelDeploys
-	responses  *ResponseBuilder
+	responses  *bot.ResponseBuilder
 
 	deployEventHandlers []DeployEventHandler
 }
@@ -35,7 +36,7 @@ func New(host string, port int, slackToken, githubToken string, store deploy.Sto
 		Addr:       fmt.Sprintf("%s:%d", host, port),
 		slackToken: slackToken,
 		deploys:    deploy.NewChannelDeploys(store),
-		responses:  NewResponseBuilder(github.NewClient(githubToken, nil)),
+		responses:  bot.NewResponseBuilder(github.NewClient(githubToken, nil)),
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -40,14 +40,14 @@ func New(host string, port int, slackToken, githubToken string, store deploy.Sto
 	}
 }
 
-func (s *Server) Start() error {
+func (s *Server) Start(h http.Handler) error {
 	listener, err := net.Listen("tcp", s.Addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s (%s)", s.Addr, err)
 	}
 	s.listener = listener
 
-	srv := http.Server{Handler: s}
+	srv := http.Server{Handler: h}
 	go func() {
 		err := srv.Serve(s.listener)
 		if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -1,42 +1,21 @@
 package server
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-
-	"github.com/andrewslotin/slack-deploy-command/bot"
-	"github.com/andrewslotin/slack-deploy-command/deploy"
-	"github.com/andrewslotin/slack-deploy-command/github"
-	"github.com/andrewslotin/slack-deploy-command/slack"
 )
-
-type DeployEventHandler interface {
-	DeployStarted(channelID string)
-	DeployCompleted(channelID string)
-}
 
 type Server struct {
 	Addr string
 
-	listener   net.Listener
-	slackToken string
-	deploys    *deploy.ChannelDeploys
-	responses  *bot.ResponseBuilder
-
-	deployEventHandlers []DeployEventHandler
+	listener net.Listener
 }
 
-func New(host string, port int, slackToken, githubToken string, store deploy.Store) *Server {
+func New(host string, port int) *Server {
 	return &Server{
-		Addr:       fmt.Sprintf("%s:%d", host, port),
-		slackToken: slackToken,
-		deploys:    deploy.NewChannelDeploys(store),
-		responses:  bot.NewResponseBuilder(github.NewClient(githubToken, nil)),
+		Addr: fmt.Sprintf("%s:%d", host, port),
 	}
 }
 
@@ -47,119 +26,16 @@ func (s *Server) Start(h http.Handler) error {
 	}
 	s.listener = listener
 
-	srv := http.Server{Handler: h}
-	go func() {
-		err := srv.Serve(s.listener)
+	go func(srv *http.Server, ln net.Listener) {
+		err := srv.Serve(ln)
 		if err != nil {
 			log.Fatal(err)
 		}
-	}()
+	}(&http.Server{Handler: h}, s.listener)
 
 	return nil
 }
 
-func (s *Server) AddDeployEventHandler(h DeployEventHandler) {
-	s.deployEventHandlers = append(s.deployEventHandlers, h)
-}
-
 func (s *Server) Shutdown() {
 	s.listener.Close()
-}
-
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(w, "Only POST requests are supported", http.StatusBadRequest)
-		return
-	}
-
-	if r.PostFormValue("token") != s.slackToken {
-		http.Error(w, "Invalid token", http.StatusForbidden)
-		return
-	}
-
-	if cmd := r.PostFormValue("command"); cmd != "/deploy" {
-		sendImmediateResponse(w, s.responses.ErrorMessage(cmd, errors.New("not supported")))
-		return
-	}
-
-	channelID := r.PostFormValue("channel_id")
-	user := slack.User{
-		ID:   r.PostFormValue("user_id"),
-		Name: r.PostFormValue("user_name"),
-	}
-
-	switch subject := r.PostFormValue("text"); subject {
-	case "", "help":
-		sendImmediateResponse(w, s.responses.HelpMessage())
-	case "status":
-		d, ok := s.deploys.Current(channelID)
-		if !ok {
-			sendImmediateResponse(w, s.responses.NoRunningDeploysMessage())
-			return
-		}
-
-		sendImmediateResponse(w, s.responses.DeployStatusMessage(d))
-	case "done":
-		d, ok := s.deploys.Finish(channelID)
-		if !ok {
-			sendImmediateResponse(w, s.responses.NoRunningDeploysMessage())
-			return
-		}
-
-		if d.User.ID == user.ID {
-			go sendDelayedResponse(w, r, s.responses.DeployDoneAnnouncement(user))
-		} else {
-			go sendDelayedResponse(w, r, s.responses.DeployInterruptedAnnouncement(d, user))
-		}
-
-		for _, h := range s.deployEventHandlers {
-			go h.DeployCompleted(channelID)
-		}
-	default:
-		d, ok := s.deploys.Start(channelID, deploy.New(user, subject))
-		if !ok {
-			sendImmediateResponse(w, s.responses.DeployInProgressMessage(d))
-			return
-		}
-
-		w.Write(nil)
-
-		go sendDelayedResponse(w, r, s.responses.DeployAnnouncement(user, subject))
-		for _, h := range s.deployEventHandlers {
-			go h.DeployStarted(channelID)
-		}
-	}
-}
-
-func sendImmediateResponse(w http.ResponseWriter, response *slack.Response) {
-	body, err := json.Marshal(response)
-	if err != nil {
-		log.Printf("failed to respond to user with %q (%s)", response.Text, err)
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(body)
-}
-
-func sendDelayedResponse(w http.ResponseWriter, req *http.Request, response *slack.Response) {
-	responseURL := req.PostFormValue("response_url")
-	if responseURL == "" {
-		log.Printf("cannot send delayed response to a without without response_url")
-		return
-	}
-
-	body, err := json.Marshal(response)
-	if err != nil {
-		log.Printf("failed to respond in channel with %s (%s)", response.Text, err)
-		return
-	}
-
-	slackResponse, err := http.Post(responseURL, "application/json", bytes.NewReader(body))
-	if err != nil {
-		log.Printf("failed to sent in_channel response (%s)", err)
-		return
-	}
-	slackResponse.Body.Close()
 }


### PR DESCRIPTION
**BREAKING** This PR changes bot endpoint to `/deploy`, while `/` now serves deploy dashboard. New `/deploy history` command responds with a link to deploy history page for current channel.

Closes #5 
