### PR TITLE
Pass channel_id to dashboard as URL path

### DIFF
--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -26,7 +26,7 @@ const (
 	deployDoneMessage         = "%s done deploying"
 	deployInterruptedMessage  = "%s has finished the deploy started by %s"
 	deployAnnouncementMessage = "%s is about to deploy %s"
-	deployHistoryLinkMessage  = "Click <https://%s/?channel_id=%s|here> to see deploy history in this channel"
+	deployHistoryLinkMessage  = "Click <https://%s/%s|here> to see deploy history in this channel"
 )
 
 type ResponseBuilder struct {
@@ -92,8 +92,9 @@ func (b *ResponseBuilder) DeployDoneAnnouncement(user slack.User) *slack.Respons
 
 func (*ResponseBuilder) DeployHistoryLink(host, channelID string) *slack.Response {
 	host = strings.TrimSuffix(strings.TrimSuffix(host, ":80"), ":443")
+	path := &url.URL{Path: channelID}
 
-	return newUserMessage(fmt.Sprintf(deployHistoryLinkMessage, host, url.QueryEscape(channelID)))
+	return newUserMessage(fmt.Sprintf(deployHistoryLinkMessage, host, path))
 }
 
 func newUserMessage(s string) *slack.Response {

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -138,7 +138,7 @@ func TestResponseBuilder_DeployHistoryLink(t *testing.T) {
 	response := b.DeployHistoryLink("www.example.com:8080", "abc 123")
 
 	assert.Equal(t, slack.ResponseTypeEphemeral, response.ResponseType)
-	assert.Contains(t, response.Text, "https://www.example.com:8080/?channel_id=abc+123")
+	assert.Contains(t, response.Text, "https://www.example.com:8080/abc%20123")
 }
 
 func TestResponseBuilder_DeployHistoryLink_StandardPorts(t *testing.T) {
@@ -148,7 +148,7 @@ func TestResponseBuilder_DeployHistoryLink_StandardPorts(t *testing.T) {
 
 	for _, port := range standardPorts {
 		response := b.DeployHistoryLink("www.example.com:"+port, "abc 123")
-		assert.Contains(t, response.Text, "https://www.example.com/?channel_id=abc+123", "port: %s", port)
+		assert.Contains(t, response.Text, "https://www.example.com/abc%20123", "port: %s", port)
 	}
 }
 

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -42,6 +42,10 @@ func New(repo deploy.Repository) *Dashboard {
 func (h *Dashboard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	channelID := r.FormValue("channel_id")
 	if channelID == "" {
+		channelID = r.URL.Path[1:]
+	}
+
+	if channelID == "" {
 		http.Error(w, "Missing channel_id", http.StatusBadRequest)
 		return
 	}

--- a/dashboard/dashboard.go
+++ b/dashboard/dashboard.go
@@ -40,13 +40,9 @@ func New(repo deploy.Repository) *Dashboard {
 }
 
 func (h *Dashboard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	channelID := r.FormValue("channel_id")
+	channelID := r.URL.Path[1:]
 	if channelID == "" {
-		channelID = r.URL.Path[1:]
-	}
-
-	if channelID == "" {
-		http.Error(w, "Missing channel_id", http.StatusBadRequest)
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		return
 	}
 

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -44,7 +44,7 @@ func TestDashboard_OneDeploy(t *testing.T) {
 
 	mux.Handle("/", dashboard.New(repo))
 
-	response, err := http.Get(url + "/?channel_id=key1")
+	response, err := http.Get(url + "/key1")
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -83,7 +83,7 @@ func TestDashboard_MultipleDeploys(t *testing.T) {
 
 	mux.Handle("/", dashboard.New(repo))
 
-	response, err := http.Get(url + "/?channel_id=key1")
+	response, err := http.Get(url + "/key1")
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)
@@ -113,7 +113,7 @@ func TestDashboard_NoDeploys(t *testing.T) {
 
 	mux.Handle("/", dashboard.New(repo))
 
-	response, err := http.Get(url + "/?channel_id=key1")
+	response, err := http.Get(url + "/key1")
 	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, response.StatusCode)

--- a/dashboard/dashboard_test.go
+++ b/dashboard/dashboard_test.go
@@ -145,7 +145,7 @@ func TestDashboard_MissingChannelID(t *testing.T) {
 	require.NoError(t, err)
 	response.Body.Close()
 
-	assert.Equal(t, http.StatusBadRequest, response.StatusCode)
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 }
 
 func setup() (url string, mux *http.ServeMux, teardownFn func()) {


### PR DESCRIPTION
Instead of passing channel_id as a query string parameter pass it in URL path, i.e.
https://example.com/?channel_id=abcDEF123 turns into https://example.com/abcDEF123.
