### PR TITLE
Send direct message when deploy is done

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -70,6 +70,7 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Name: r.PostFormValue("user_name"),
 	}
 
+	// TODO: make commands case-insensitive
 	switch subject := r.PostFormValue("text"); subject {
 	case "", "help":
 		sendImmediateResponse(w, b.responses.HelpMessage())
@@ -114,7 +115,7 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		w.Write(nil)
 
-		go sendDelayedResponse(w, r, b.responses.DeployAnnouncement(user, subject))
+		go sendDelayedResponse(w, r, b.responses.DeployAnnouncement(d))
 		for _, h := range b.deployEventHandlers {
 			go h.DeployStarted(channelID)
 		}

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -14,8 +14,8 @@ import (
 )
 
 type DeployEventHandler interface {
-	DeployStarted(channelID string)
-	DeployCompleted(channelID string)
+	DeployStarted(channelID string, d deploy.Deploy)
+	DeployCompleted(channelID string, d deploy.Deploy)
 }
 
 type Bot struct {
@@ -96,7 +96,7 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, h := range b.deployEventHandlers {
-			go h.DeployCompleted(channelID)
+			go h.DeployCompleted(channelID, d)
 		}
 	case "history":
 		dashboardToken, err := b.dashboardAuth.IssueToken(auth.DefaultTokenLength)
@@ -117,7 +117,7 @@ func (b *Bot) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		go sendDelayedResponse(w, r, b.responses.DeployAnnouncement(d))
 		for _, h := range b.deployEventHandlers {
-			go h.DeployStarted(channelID)
+			go h.DeployStarted(channelID, d)
 		}
 	}
 }

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -61,10 +61,10 @@ func (b *ResponseBuilder) DeployInterruptedAnnouncement(d deploy.Deploy, user sl
 	return newAnnouncement(fmt.Sprintf(deployInterruptedMessage, user, d.User))
 }
 
-func (b *ResponseBuilder) DeployAnnouncement(user slack.User, subject string) *slack.Response {
-	responseText := fmt.Sprintf(deployAnnouncementMessage, user, slack.EscapeMessage(subject))
+func (b *ResponseBuilder) DeployAnnouncement(d deploy.Deploy) *slack.Response {
+	responseText := fmt.Sprintf(deployAnnouncementMessage, d.User, slack.EscapeMessage(d.Subject))
 	response := newAnnouncement(responseText)
-	for _, ref := range deploy.FindPullRequestReferences(subject) {
+	for _, ref := range deploy.FindPullRequestReferences(d.Subject) {
 		pr, err := b.githubClient.GetPullRequest(ref.Repository, ref.ID)
 		if err != nil {
 			response.Attachments = append(response.Attachments, slack.Attachment{

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -64,7 +64,7 @@ func (b *ResponseBuilder) DeployInterruptedAnnouncement(d deploy.Deploy, user sl
 func (b *ResponseBuilder) DeployAnnouncement(d deploy.Deploy) *slack.Response {
 	responseText := fmt.Sprintf(deployAnnouncementMessage, d.User, slack.EscapeMessage(d.Subject))
 	response := newAnnouncement(responseText)
-	for _, ref := range deploy.FindPullRequestReferences(d.Subject) {
+	for _, ref := range d.PullRequests {
 		pr, err := b.githubClient.GetPullRequest(ref.Repository, ref.ID)
 		if err != nil {
 			response.Attachments = append(response.Attachments, slack.Attachment{

--- a/bot/response_builder.go
+++ b/bot/response_builder.go
@@ -64,7 +64,7 @@ func (b *ResponseBuilder) DeployInterruptedAnnouncement(d deploy.Deploy, user sl
 func (b *ResponseBuilder) DeployAnnouncement(user slack.User, subject string) *slack.Response {
 	responseText := fmt.Sprintf(deployAnnouncementMessage, user, slack.EscapeMessage(subject))
 	response := newAnnouncement(responseText)
-	for _, ref := range deploy.FindReferences(subject) {
+	for _, ref := range deploy.FindPullRequestReferences(subject) {
 		pr, err := b.githubClient.GetPullRequest(ref.Repository, ref.ID)
 		if err != nil {
 			response.Attachments = append(response.Attachments, slack.Attachment{

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -103,7 +103,7 @@ func TestResponseBuilder_DeployAnnouncement(t *testing.T) {
 
 	d := deploy.Deploy{
 		User:    slack.User{ID: "abc123", Name: "user1"},
-		Subject: "user1/repo1#123 and user2/repo2#234",
+		Subject: "new feature",
 		PullRequests: []deploy.PullRequestReference{
 			{ID: "123", Repository: "user1/repo1"},
 			{ID: "234", Repository: "user2/repo2"},

--- a/bot/response_builder_test.go
+++ b/bot/response_builder_test.go
@@ -101,14 +101,22 @@ func TestResponseBuilder_DeployAnnouncement(t *testing.T) {
 	githubClient := github.NewClient("", nil)
 	githubClient.BaseURL = baseURL
 
-	user := slack.User{ID: "abc123", Name: "user1"}
+	d := deploy.Deploy{
+		User:    slack.User{ID: "abc123", Name: "user1"},
+		Subject: "user1/repo1#123 and user2/repo2#234",
+		PullRequests: []deploy.PullRequestReference{
+			{ID: "123", Repository: "user1/repo1"},
+			{ID: "234", Repository: "user2/repo2"},
+		},
+		StartedAt: time.Now(),
+	}
 
 	b := bot.NewResponseBuilder(githubClient)
-	response := b.DeployAnnouncement(user, "user1/repo1#123 and user2/repo2#234")
+	response := b.DeployAnnouncement(d)
 
 	assert.Equal(t, slack.ResponseTypeInChannel, response.ResponseType)
-	assert.Contains(t, response.Text, user.String())
-	assert.Contains(t, response.Text, "user1/repo1#123 and user2/repo2#234")
+	assert.Contains(t, response.Text, d.User.String())
+	assert.Contains(t, response.Text, d.Subject)
 
 	if assert.Len(t, response.Attachments, 2) {
 		assert.Equal(t, "PR #123: Hello", response.Attachments[0].Title)

--- a/bot/slack_im_notifier.go
+++ b/bot/slack_im_notifier.go
@@ -1,0 +1,46 @@
+package bot
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/andrewslotin/michael/deploy"
+	"github.com/andrewslotin/michael/slack"
+)
+
+type SlackIMNotifier struct {
+	im    *slack.InstantMessenger
+	users *slack.TeamDirectory
+}
+
+func NewSlackIMNotifier(api *slack.WebAPI) *SlackIMNotifier {
+	return &SlackIMNotifier{
+		im:    slack.NewInstantMessenger(api),
+		users: slack.NewTeamDirectory(api),
+	}
+}
+
+func (notifier *SlackIMNotifier) DeployStarted(_ string, _ deploy.Deploy) {}
+
+func (notifier *SlackIMNotifier) DeployCompleted(_ string, d deploy.Deploy) {
+	for _, userRef := range d.InterestedUsers {
+		user, err := notifier.users.Fetch(userRef.Name)
+		if err != nil {
+			if _, ok := err.(slack.NoSuchUserError); !ok {
+				log.Printf("cannot notify %s about completed deploy of %s: %s", user.Name, d.Subject, err)
+			}
+
+			continue
+		}
+
+		message := slack.Message{
+			Text: fmt.Sprintf("%s just deployed %s", d.User, d.Subject),
+		}
+
+		err = notifier.im.SendMessage(user, message)
+		if err != nil {
+			log.Printf("failed to send an instant message to %s: %s", user.Name, err)
+			continue
+		}
+	}
+}

--- a/bot/slack_im_notifier.go
+++ b/bot/slack_im_notifier.go
@@ -23,7 +23,7 @@ func NewSlackIMNotifier(api *slack.WebAPI) *SlackIMNotifier {
 func (notifier *SlackIMNotifier) DeployStarted(_ string, _ deploy.Deploy) {}
 
 func (notifier *SlackIMNotifier) DeployCompleted(_ string, d deploy.Deploy) {
-	for _, userRef := range d.InterestedUsers {
+	for _, userRef := range d.Subscribers {
 		user, err := notifier.users.Fetch(userRef.Name)
 		if err != nil {
 			if _, ok := err.(slack.NoSuchUserError); !ok {

--- a/bot/slack_im_notifier_test.go
+++ b/bot/slack_im_notifier_test.go
@@ -1,0 +1,92 @@
+package bot_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/andrewslotin/michael/bot"
+	"github.com/andrewslotin/michael/deploy"
+	"github.com/andrewslotin/michael/slack"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlackIMNotifier_DeployCompleted(t *testing.T) {
+	const webAPIToken = "xxxxx-token1"
+
+	d := deploy.Deploy{
+		User:    slack.User{ID: "U1", Name: "author"},
+		Subject: "Deploy subject",
+		InterestedUsers: []deploy.UserReference{
+			{"recipient1"},
+			{"nonExistingRecipient"},
+			{"recipient2"},
+		},
+	}
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	var (
+		requestNum struct{ UsersList, IMOpen int }
+		receivers  []string
+	)
+
+	mux.HandleFunc("/users.list", func(w http.ResponseWriter, r *http.Request) {
+		requestNum.UsersList++
+		assert.Equal(t, webAPIToken, r.FormValue("token"))
+
+		fmt.Fprint(w, `{"ok":true,"members":[{"id":"R1","name":"recipient1"},{"id":"R2","name":"recipient2"},{"id":"R3","name":"recipient3"}]}`)
+	})
+	mux.HandleFunc("/im.open", func(w http.ResponseWriter, r *http.Request) {
+		requestNum.IMOpen++
+		assert.Equal(t, webAPIToken, r.FormValue("token"))
+
+		if userID := r.FormValue("user"); assert.NotEmpty(t, userID) {
+			fmt.Fprintf(w, `{"ok":true,"channel":{"id":"DM%s"}}`, userID)
+		} else {
+			fmt.Fprint(w, `{"ok":false,"error":"user_not_found"}`)
+		}
+	})
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, webAPIToken, r.FormValue("token"))
+
+		if channelID := r.FormValue("channel"); assert.NotEmpty(t, channelID) {
+			receivers = append(receivers, channelID)
+		}
+
+		if msg := r.FormValue("text"); assert.NotEmpty(t, msg) {
+			assert.Contains(t, msg, d.User.String())
+			assert.Contains(t, msg, d.Subject)
+		}
+
+		fmt.Fprint(w, `{"ok":true}`)
+	})
+
+	api := slack.NewWebAPI(webAPIToken, nil)
+	api.BaseURL = server.URL
+
+	notifier := bot.NewSlackIMNotifier(api)
+	notifier.DeployCompleted("", d)
+
+	assert.Equal(t, 2, requestNum.UsersList) // nonExistingRecipient will not hit the cache
+	assert.Equal(t, 2, requestNum.IMOpen)
+
+	if assert.Len(t, receivers, 2) {
+		assert.Contains(t, receivers, "DMR1")
+		assert.Contains(t, receivers, "DMR2")
+	}
+
+	// Retry to check user list caching
+	receivers = receivers[:0]
+	notifier.DeployCompleted("", d)
+	assert.Equal(t, 3, requestNum.UsersList) // +1 request because of nonExistingRecipient
+	assert.Equal(t, 2, requestNum.IMOpen)    // no new channels are expected to be open
+
+	if assert.Len(t, receivers, 2) {
+		assert.Contains(t, receivers, "DMR1")
+		assert.Contains(t, receivers, "DMR2")
+	}
+}

--- a/bot/slack_im_notifier_test.go
+++ b/bot/slack_im_notifier_test.go
@@ -18,7 +18,7 @@ func TestSlackIMNotifier_DeployCompleted(t *testing.T) {
 	d := deploy.Deploy{
 		User:    slack.User{ID: "U1", Name: "author"},
 		Subject: "Deploy subject",
-		InterestedUsers: []deploy.UserReference{
+		Subscribers: []deploy.UserReference{
 			{"recipient1"},
 			{"nonExistingRecipient"},
 			{"recipient2"},

--- a/bot/slack_topic_manager.go
+++ b/bot/slack_topic_manager.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/andrewslotin/michael/deploy"
 	"github.com/andrewslotin/michael/slack"
 )
 
@@ -20,7 +21,7 @@ func NewSlackTopicManager(webAPIClient *slack.WebAPI) *SlackTopicManager {
 	return &SlackTopicManager{api: webAPIClient}
 }
 
-func (mgr *SlackTopicManager) DeployStarted(channelID string) {
+func (mgr *SlackTopicManager) DeployStarted(channelID string, _ deploy.Deploy) {
 	currentTopic, err := mgr.api.GetChannelTopic(channelID)
 	if err == nil {
 		newTopic := strings.Replace(currentTopic, DeployDoneEmotion, DeployInProgressEmotion, -1)
@@ -34,7 +35,7 @@ func (mgr *SlackTopicManager) DeployStarted(channelID string) {
 	}
 }
 
-func (mgr *SlackTopicManager) DeployCompleted(channelID string) {
+func (mgr *SlackTopicManager) DeployCompleted(channelID string, _ deploy.Deploy) {
 	currentTopic, err := mgr.api.GetChannelTopic(channelID)
 	if err == nil {
 		newTopic := strings.Replace(currentTopic, DeployInProgressEmotion, DeployDoneEmotion, -1)

--- a/bot/slack_topic_manager_test.go
+++ b/bot/slack_topic_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/andrewslotin/michael/bot"
+	"github.com/andrewslotin/michael/deploy"
 	"github.com/andrewslotin/michael/slack"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,7 +30,7 @@ func TestSlackTopicManager_DeployStarted_NoRunningDeploy(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployStarted(channel.ID)
+	mgr.DeployStarted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
 }
@@ -45,7 +46,7 @@ func TestSlackTopicManager_DeployStarted_NoTopicNotification(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployStarted(channel.ID)
+	mgr.DeployStarted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:=-", channel.Topic)
 }
@@ -61,7 +62,7 @@ func TestSlackTopicManager_DeployStarted_InProgress(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployStarted(channel.ID)
+	mgr.DeployStarted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployInProgressEmotion, 3)+":poop:=-", channel.Topic)
 }
@@ -77,7 +78,7 @@ func TestSlackTopicManager_DeployCompleted_InProgress(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployCompleted(channel.ID)
+	mgr.DeployCompleted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
 }
@@ -93,7 +94,7 @@ func TestSlackTopicManager_DeployCompleted_NoTopicNotification(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployCompleted(channel.ID)
+	mgr.DeployCompleted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:=-", channel.Topic)
 }
@@ -109,7 +110,7 @@ func TestSlackTopicManager_DeployCompleted_NoRunningDeploy(t *testing.T) {
 	webAPI.BaseURL = baseURL
 
 	mgr := bot.NewSlackTopicManager(webAPI)
-	mgr.DeployCompleted(channel.ID)
+	mgr.DeployCompleted(channel.ID, deploy.Deploy{})
 
 	assert.Equal(t, "-=:poop:"+strings.Repeat(bot.DeployDoneEmotion, 3)+":poop:=-", channel.Topic)
 }

--- a/deploy/bolt_db_store.go
+++ b/deploy/bolt_db_store.go
@@ -17,6 +17,7 @@ const (
 	startedAtKey    = "started_at"
 	finishedAtKey   = "finished_at"
 	pullRequestsKey = "prs"
+	usersKey        = "users"
 )
 
 var (
@@ -173,6 +174,15 @@ func (s *BoltDBStore) writeDeploy(deploy Deploy, channelBucket *bolt.Bucket) err
 		b.Put([]byte(pullRequestsKey), data)
 	}
 
+	if len(deploy.InterestedUsers) != 0 {
+		data, err := json.Marshal(deploy.InterestedUsers)
+		if err != nil {
+			return err
+		}
+
+		b.Put([]byte(usersKey), data)
+	}
+
 	return nil
 }
 
@@ -205,6 +215,12 @@ func (*BoltDBStore) readDeploy(key []byte, channelBucket *bolt.Bucket) (deploy D
 	if value := b.Get([]byte(pullRequestsKey)); value != nil {
 		if err := json.Unmarshal(value, &deploy.PullRequests); err != nil {
 			return deploy, fmt.Errorf("malformed prs for deploy of %s by %s: %s", deploy.Subject, deploy.User.Name, err)
+		}
+	}
+
+	if value := b.Get([]byte(usersKey)); value != nil {
+		if err := json.Unmarshal(value, &deploy.InterestedUsers); err != nil {
+			return deploy, fmt.Errorf("malformed users for deploy of %s by %s: %s", deploy.Subject, deploy.User.Name, err)
 		}
 	}
 

--- a/deploy/bolt_db_store.go
+++ b/deploy/bolt_db_store.go
@@ -17,7 +17,7 @@ const (
 	startedAtKey    = "started_at"
 	finishedAtKey   = "finished_at"
 	pullRequestsKey = "prs"
-	usersKey        = "users"
+	subscribersKey  = "subscribers"
 )
 
 var (
@@ -174,13 +174,13 @@ func (s *BoltDBStore) writeDeploy(deploy Deploy, channelBucket *bolt.Bucket) err
 		b.Put([]byte(pullRequestsKey), data)
 	}
 
-	if len(deploy.InterestedUsers) != 0 {
-		data, err := json.Marshal(deploy.InterestedUsers)
+	if len(deploy.Subscribers) != 0 {
+		data, err := json.Marshal(deploy.Subscribers)
 		if err != nil {
 			return err
 		}
 
-		b.Put([]byte(usersKey), data)
+		b.Put([]byte(subscribersKey), data)
 	}
 
 	return nil
@@ -218,8 +218,8 @@ func (*BoltDBStore) readDeploy(key []byte, channelBucket *bolt.Bucket) (deploy D
 		}
 	}
 
-	if value := b.Get([]byte(usersKey)); value != nil {
-		if err := json.Unmarshal(value, &deploy.InterestedUsers); err != nil {
+	if value := b.Get([]byte(subscribersKey)); value != nil {
+		if err := json.Unmarshal(value, &deploy.Subscribers); err != nil {
 			return deploy, fmt.Errorf("malformed users for deploy of %s by %s: %s", deploy.Subject, deploy.User.Name, err)
 		}
 	}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -7,14 +7,19 @@ import (
 )
 
 type Deploy struct {
-	User       slack.User
-	Subject    string
-	StartedAt  time.Time
-	FinishedAt time.Time
+	User         slack.User
+	Subject      string
+	StartedAt    time.Time
+	FinishedAt   time.Time
+	PullRequests []PullRequestReference
 }
 
 func New(user slack.User, subject string) Deploy {
-	return Deploy{User: user, Subject: subject}
+	return Deploy{
+		User:         user,
+		Subject:      subject,
+		PullRequests: FindPullRequestReferences(subject),
+	}
 }
 
 func (d *Deploy) Start() bool {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -7,18 +7,20 @@ import (
 )
 
 type Deploy struct {
-	User         slack.User
-	Subject      string
-	StartedAt    time.Time
-	FinishedAt   time.Time
-	PullRequests []PullRequestReference
+	User            slack.User
+	Subject         string
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	PullRequests    []PullRequestReference
+	InterestedUsers []UserReference
 }
 
 func New(user slack.User, subject string) Deploy {
 	return Deploy{
-		User:         user,
-		Subject:      subject,
-		PullRequests: FindPullRequestReferences(subject),
+		User:            user,
+		Subject:         subject,
+		PullRequests:    FindPullRequestReferences(subject),
+		InterestedUsers: FindUserReferences(subject),
 	}
 }
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -7,20 +7,20 @@ import (
 )
 
 type Deploy struct {
-	User            slack.User
-	Subject         string
-	StartedAt       time.Time
-	FinishedAt      time.Time
-	PullRequests    []PullRequestReference
-	InterestedUsers []UserReference
+	User         slack.User
+	Subject      string
+	StartedAt    time.Time
+	FinishedAt   time.Time
+	PullRequests []PullRequestReference
+	Subscribers  []UserReference
 }
 
 func New(user slack.User, subject string) Deploy {
 	return Deploy{
-		User:            user,
-		Subject:         subject,
-		PullRequests:    FindPullRequestReferences(subject),
-		InterestedUsers: FindUserReferences(subject),
+		User:         user,
+		Subject:      subject,
+		PullRequests: FindPullRequestReferences(subject),
+		Subscribers:  FindUserReferences(subject),
 	}
 }
 

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewDeploy(t *testing.T) {
+	var (
+		user    = slack.User{ID: "1", Name: "Test User"}
+		subject = "Test deploy https://github.com/a/b/pull/123 and x/y#4"
+	)
+
+	d := deploy.New(user, subject)
+	assert.Equal(t, user, d.User)
+	assert.Equal(t, subject, d.Subject)
+	assert.Zero(t, d.StartedAt)
+	assert.Zero(t, d.FinishedAt)
+
+	if assert.Len(t, d.PullRequests, 2) {
+		assert.Contains(t, d.PullRequests, deploy.PullRequestReference{ID: "123", Repository: "a/b"})
+		assert.Contains(t, d.PullRequests, deploy.PullRequestReference{ID: "4", Repository: "x/y"})
+	}
+}
+
 func TestDeploy_Start(t *testing.T) {
 	d := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Test deploy")
 	assert.True(t, d.Start())

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -26,8 +26,8 @@ func TestNewDeploy(t *testing.T) {
 		assert.Contains(t, d.PullRequests, deploy.PullRequestReference{ID: "4", Repository: "x/y"})
 	}
 
-	if assert.Len(t, d.InterestedUsers, 1) {
-		assert.Contains(t, d.InterestedUsers, deploy.UserReference{Name: "user1"})
+	if assert.Len(t, d.Subscribers, 1) {
+		assert.Contains(t, d.Subscribers, deploy.UserReference{Name: "user1"})
 	}
 }
 

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewDeploy(t *testing.T) {
 	var (
 		user    = slack.User{ID: "1", Name: "Test User"}
-		subject = "Test deploy https://github.com/a/b/pull/123 and x/y#4"
+		subject = "Test deploy https://github.com/a/b/pull/123 and x/y#4 for @user1"
 	)
 
 	d := deploy.New(user, subject)
@@ -24,6 +24,10 @@ func TestNewDeploy(t *testing.T) {
 	if assert.Len(t, d.PullRequests, 2) {
 		assert.Contains(t, d.PullRequests, deploy.PullRequestReference{ID: "123", Repository: "a/b"})
 		assert.Contains(t, d.PullRequests, deploy.PullRequestReference{ID: "4", Repository: "x/y"})
+	}
+
+	if assert.Len(t, d.InterestedUsers, 1) {
+		assert.Contains(t, d.InterestedUsers, deploy.UserReference{Name: "user1"})
 	}
 }
 

--- a/deploy/references.go
+++ b/deploy/references.go
@@ -12,6 +12,13 @@ var (
 		regexp.MustCompile("^(?P<repository>\\S+/\\S+)#(?P<number>\\d+)[^A-Za-z]?$"),                        // octocat/helloworld#12
 		regexp.MustCompile("^https?://github.com/(?P<repository>\\S+/\\S+)/pull/(?P<number>\\d+)(?:\\?|$)"), // https://github.com/octocat/helloworld/pull/12
 	}
+	userReferenceRegexes = []*regexp.Regexp{
+		// Usernames can be up to 21 characters long. They can contain lowercase letters a to z (without accents),
+		// numbers 0 to 9, hyphens, periods, and underscores.
+		//
+		// See https://get.slack.help/hc/en-us/articles/216360827-Change-your-username
+		regexp.MustCompile("^@(?P<username>[A-Za-z0-9\\._-]+)"),
+	}
 )
 
 type PullRequestReference struct {
@@ -49,6 +56,46 @@ func extractPullRequestReference(s string, re *regexp.Regexp) (ref PullRequestRe
 			ref.Repository = m[i]
 		case "number":
 			ref.ID = m[i]
+		default:
+			continue
+		}
+	}
+
+	return ref, true
+}
+
+type UserReference struct {
+	Name string
+}
+
+func FindUserReferences(s string) []UserReference {
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	scanner.Split(bufio.ScanWords)
+
+	var refs []UserReference
+	for scanner.Scan() {
+		word := scanner.Text()
+
+		for _, re := range userReferenceRegexes {
+			if ref, ok := extractUserReference(word, re); ok {
+				refs = append(refs, ref)
+			}
+		}
+	}
+
+	return refs
+}
+
+func extractUserReference(s string, re *regexp.Regexp) (ref UserReference, ok bool) {
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return ref, false
+	}
+
+	for i, name := range re.SubexpNames() {
+		switch name {
+		case "username":
+			ref.Name = m[i]
 		default:
 			continue
 		}

--- a/deploy/references.go
+++ b/deploy/references.go
@@ -7,27 +7,28 @@ import (
 )
 
 var (
-	referenceRegexes = []*regexp.Regexp{
+	// TODO: support anchors in GitHub URLs along with query string parameters
+	pullRequestReferenceRegexes = []*regexp.Regexp{
 		regexp.MustCompile("^(?P<repository>\\S+/\\S+)#(?P<number>\\d+)[^A-Za-z]?$"),                        // octocat/helloworld#12
 		regexp.MustCompile("^https?://github.com/(?P<repository>\\S+/\\S+)/pull/(?P<number>\\d+)(?:\\?|$)"), // https://github.com/octocat/helloworld/pull/12
 	}
 )
 
-type Reference struct {
+type PullRequestReference struct {
 	ID         string
 	Repository string
 }
 
-func FindReferences(s string) []Reference {
+func FindPullRequestReferences(s string) []PullRequestReference {
 	scanner := bufio.NewScanner(strings.NewReader(s))
 	scanner.Split(bufio.ScanWords)
 
-	var refs []Reference
+	var refs []PullRequestReference
 	for scanner.Scan() {
 		word := scanner.Text()
 
-		for _, re := range referenceRegexes {
-			if ref, ok := extractReference(word, re); ok {
+		for _, re := range pullRequestReferenceRegexes {
+			if ref, ok := extractPullRequestReference(word, re); ok {
 				refs = append(refs, ref)
 			}
 		}
@@ -36,7 +37,7 @@ func FindReferences(s string) []Reference {
 	return refs
 }
 
-func extractReference(s string, re *regexp.Regexp) (ref Reference, ok bool) {
+func extractPullRequestReference(s string, re *regexp.Regexp) (ref PullRequestReference, ok bool) {
 	m := re.FindStringSubmatch(s)
 	if m == nil {
 		return ref, false

--- a/deploy/references_test.go
+++ b/deploy/references_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindReferences_Short(t *testing.T) {
+func TestFindPullRequestReferences_Short(t *testing.T) {
 	s := "user project 123 user/ /project user/#123 /project#123 /# #/123 use/project user/project#123 user/project#1a"
 
-	refs := deploy.FindReferences(s)
+	refs := deploy.FindPullRequestReferences(s)
 	require.Len(t, refs, 1)
 
 	ref := refs[0]
@@ -19,10 +19,10 @@ func TestFindReferences_Short(t *testing.T) {
 	assert.Equal(t, "user/project", ref.Repository)
 }
 
-func TestFindReferences_GitHubLink(t *testing.T) {
+func TestFindPullRequestReferences_GitHubLink(t *testing.T) {
 	s := "https://github.com/user/project/pull/1 https://github.com/user/project/issues/2 https://github.com/user/project/pulls https://bitbucket.org/user/project/pull/3"
 
-	refs := deploy.FindReferences(s)
+	refs := deploy.FindPullRequestReferences(s)
 	require.Len(t, refs, 1)
 
 	ref := refs[0]
@@ -30,10 +30,10 @@ func TestFindReferences_GitHubLink(t *testing.T) {
 	assert.Equal(t, "user/project", ref.Repository)
 }
 
-func TestFindReferences_Mixed_Multiple(t *testing.T) {
+func TestFindPullRequestReferences_Mixed_Multiple(t *testing.T) {
 	s := "userA/projectA#1, https://github.com/userB/projectB/pull/2 and userC/projectC#3"
 
-	refs := deploy.FindReferences(s)
+	refs := deploy.FindPullRequestReferences(s)
 	require.Len(t, refs, 3)
 
 	// userA/projectA#1

--- a/deploy/references_test.go
+++ b/deploy/references_test.go
@@ -5,46 +5,58 @@ import (
 
 	"github.com/andrewslotin/michael/deploy"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFindPullRequestReferences_Short(t *testing.T) {
 	s := "user project 123 user/ /project user/#123 /project#123 /# #/123 use/project user/project#123 user/project#1a"
 
 	refs := deploy.FindPullRequestReferences(s)
-	require.Len(t, refs, 1)
-
-	ref := refs[0]
-	assert.Equal(t, "123", ref.ID)
-	assert.Equal(t, "user/project", ref.Repository)
+	if assert.Len(t, refs, 1) {
+		assert.Contains(t, refs, deploy.PullRequestReference{ID: "123", Repository: "user/project"})
+	}
 }
 
 func TestFindPullRequestReferences_GitHubLink(t *testing.T) {
-	s := "https://github.com/user/project/pull/1 https://github.com/user/project/issues/2 https://github.com/user/project/pulls https://bitbucket.org/user/project/pull/3"
+	s := "" +
+		"https://github.com/user/project/pull/1 " +
+		"https://github.com/user/project/issues/2 " +
+		"https://github.com/user/project/pulls " +
+		"https://bitbucket.org/user/project/pull/3"
 
 	refs := deploy.FindPullRequestReferences(s)
-	require.Len(t, refs, 1)
-
-	ref := refs[0]
-	assert.Equal(t, "1", ref.ID)
-	assert.Equal(t, "user/project", ref.Repository)
+	if assert.Len(t, refs, 1) {
+		assert.Contains(t, refs, deploy.PullRequestReference{ID: "1", Repository: "user/project"})
+	}
 }
 
 func TestFindPullRequestReferences_Mixed_Multiple(t *testing.T) {
-	s := "userA/projectA#1, https://github.com/userB/projectB/pull/2 and userC/projectC#3"
+	s := "" +
+		"userA/projectA#1, " +
+		"https://github.com/userB/projectB/pull/2 " +
+		"and userC/projectC#3"
 
 	refs := deploy.FindPullRequestReferences(s)
-	require.Len(t, refs, 3)
+	if assert.Len(t, refs, 3) {
+		// userA/projectA#1
+		assert.Contains(t, refs, deploy.PullRequestReference{ID: "1", Repository: "userA/projectA"})
 
-	// userA/projectA#1
-	assert.Equal(t, "1", refs[0].ID)
-	assert.Equal(t, "userA/projectA", refs[0].Repository)
+		// userB/projectB#2
+		assert.Contains(t, refs, deploy.PullRequestReference{ID: "2", Repository: "userB/projectB"})
 
-	// userB/projectB#2
-	assert.Equal(t, "2", refs[1].ID)
-	assert.Equal(t, "userB/projectB", refs[1].Repository)
+		// userC/projectC#3
+		assert.Contains(t, refs, deploy.PullRequestReference{ID: "3", Repository: "userC/projectC"})
+	}
+}
 
-	// userC/projectC#3
-	assert.Equal(t, "3", refs[2].ID)
-	assert.Equal(t, "userC/projectC", refs[2].Repository)
+func TestFindUserReferences(t *testing.T) {
+	s := "" +
+		"hello @person_1, my email is writeme@gmail.com, see you @ the bar. " +
+		"if you see @person.2 please send him to @me"
+
+	refs := deploy.FindUserReferences(s)
+	if assert.Len(t, refs, 3) {
+		assert.Contains(t, refs, deploy.UserReference{Name: "person_1"})
+		assert.Contains(t, refs, deploy.UserReference{Name: "person.2"})
+		assert.Contains(t, refs, deploy.UserReference{Name: "me"})
+	}
 }

--- a/deploy/store_test.go
+++ b/deploy/store_test.go
@@ -24,27 +24,30 @@ func (suite *StoreSuite) TestGetSet() {
 	assert.False(suite.T(), ok)
 
 	// Store a value
-	channel1Deploy := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Deploy subject a/b#1")
+	channel1Deploy := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Deploy subject a/b#1 for @user")
 	channel1Deploy.Start()
 	store.Set("key1", channel1Deploy)
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
 		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
+		assert.Equal(suite.T(), channel1Deploy.InterestedUsers, d.InterestedUsers)
 	}
 
 	// Populate another key
-	channel2Deploy := deploy.New(slack.User{ID: "2", Name: "Second User"}, "Another deploy c/d#2")
+	channel2Deploy := deploy.New(slack.User{ID: "2", Name: "Second User"}, "Another deploy c/d#2 for @another_user")
 	channel2Deploy.Start()
 	store.Set("key2", channel2Deploy)
 	if d, ok := store.Get("key2"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel2Deploy, d)
 		assert.Equal(suite.T(), channel2Deploy.PullRequests, d.PullRequests)
+		assert.Equal(suite.T(), channel2Deploy.InterestedUsers, d.InterestedUsers)
 	}
 
 	// Check that another record wasn't changed
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
 		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
+		assert.Equal(suite.T(), channel1Deploy.InterestedUsers, d.InterestedUsers)
 	}
 }
 

--- a/deploy/store_test.go
+++ b/deploy/store_test.go
@@ -30,7 +30,7 @@ func (suite *StoreSuite) TestGetSet() {
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
 		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
-		assert.Equal(suite.T(), channel1Deploy.InterestedUsers, d.InterestedUsers)
+		assert.Equal(suite.T(), channel1Deploy.Subscribers, d.Subscribers)
 	}
 
 	// Populate another key
@@ -40,14 +40,14 @@ func (suite *StoreSuite) TestGetSet() {
 	if d, ok := store.Get("key2"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel2Deploy, d)
 		assert.Equal(suite.T(), channel2Deploy.PullRequests, d.PullRequests)
-		assert.Equal(suite.T(), channel2Deploy.InterestedUsers, d.InterestedUsers)
+		assert.Equal(suite.T(), channel2Deploy.Subscribers, d.Subscribers)
 	}
 
 	// Check that another record wasn't changed
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
 		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
-		assert.Equal(suite.T(), channel1Deploy.InterestedUsers, d.InterestedUsers)
+		assert.Equal(suite.T(), channel1Deploy.Subscribers, d.Subscribers)
 	}
 }
 

--- a/deploy/store_test.go
+++ b/deploy/store_test.go
@@ -24,24 +24,27 @@ func (suite *StoreSuite) TestGetSet() {
 	assert.False(suite.T(), ok)
 
 	// Store a value
-	channel1Deploy := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Deploy subject")
+	channel1Deploy := deploy.New(slack.User{ID: "1", Name: "Test User"}, "Deploy subject a/b#1")
 	channel1Deploy.Start()
 	store.Set("key1", channel1Deploy)
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
+		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
 	}
 
 	// Populate another key
-	channel2Deploy := deploy.New(slack.User{ID: "2", Name: "Second User"}, "Another deploy")
+	channel2Deploy := deploy.New(slack.User{ID: "2", Name: "Second User"}, "Another deploy c/d#2")
 	channel2Deploy.Start()
 	store.Set("key2", channel2Deploy)
 	if d, ok := store.Get("key2"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel2Deploy, d)
+		assert.Equal(suite.T(), channel2Deploy.PullRequests, d.PullRequests)
 	}
 
 	// Check that another record wasn't changed
 	if d, ok := store.Get("key1"); assert.True(suite.T(), ok) {
 		assert.Equal(suite.T(), channel1Deploy, d)
+		assert.Equal(suite.T(), channel1Deploy.PullRequests, d.PullRequests)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -100,7 +100,10 @@ func main() {
 
 	if slackWebAPIToken := os.Getenv("SLACK_WEBAPI_TOKEN"); slackWebAPIToken != "" {
 		api := slack.NewWebAPI(slackWebAPIToken, nil)
+		// Update channel topic to reflect current deploy status
 		slackBot.AddDeployEventHandler(bot.NewSlackTopicManager(api))
+		// Send direct messages to users mentioned in deploy subject
+		slackBot.AddDeployEventHandler(bot.NewSlackIMNotifier(api))
 	} else {
 		log.Printf("SLACK_WEBAPI_TOKEN env variable not set, channel topic notifications are disabled")
 	}

--- a/slack/errors.go
+++ b/slack/errors.go
@@ -1,0 +1,9 @@
+package slack
+
+type NoSuchUserError struct {
+	Name string
+}
+
+func (e NoSuchUserError) Error() string {
+	return "there is no user with username '" + e.Name + "' in the team"
+}

--- a/slack/instant_messenger.go
+++ b/slack/instant_messenger.go
@@ -1,0 +1,58 @@
+package slack
+
+import "sync"
+
+type messageSender interface {
+	OpenIMChannel(User) (string, error)
+	PostMessage(string, Message) error
+}
+
+type InstantMessenger struct {
+	api messageSender
+
+	mu       sync.RWMutex
+	channels map[string]string
+}
+
+func NewInstantMessenger(api messageSender) *InstantMessenger {
+	return &InstantMessenger{
+		api:      api,
+		channels: make(map[string]string),
+	}
+}
+
+func (im *InstantMessenger) SendMessage(user User, message Message) error {
+	channelID, err := im.openChannel(user)
+	if err != nil {
+		return err
+	}
+
+	return im.api.PostMessage(channelID, message)
+}
+
+func (im *InstantMessenger) openChannel(user User) (string, error) {
+	im.mu.RLock()
+	channelID, ok := im.channels[user.Name]
+	im.mu.RUnlock()
+
+	if ok {
+		return channelID, nil
+	}
+
+	im.mu.Lock()
+	defer im.mu.Unlock()
+
+	channelID, ok = im.channels[user.Name]
+	if ok {
+		return channelID, nil
+	}
+
+	channelID, err := im.api.OpenIMChannel(user)
+	if err != nil {
+		return "", err
+	}
+
+	im.channels[user.Name] = channelID
+
+	return im.channels[user.Name], nil
+}

--- a/slack/instant_messenger_test.go
+++ b/slack/instant_messenger_test.go
@@ -1,0 +1,82 @@
+package slack_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/andrewslotin/michael/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstantMessenger_SendMessage(t *testing.T) {
+	user := slack.User{ID: "123", Name: "user1"}
+	message := slack.Message{Text: "text message"}
+
+	api := new(messageSenderMock)
+	api.On("OpenIMChannel", user).Return("channel1", nil)
+	api.On("PostMessage", "channel1", message).Return(nil)
+
+	im := slack.NewInstantMessenger(api)
+	require.NoError(t, im.SendMessage(user, message))
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 1)
+	api.AssertNumberOfCalls(t, "PostMessage", 1)
+
+	require.NoError(t, im.SendMessage(user, message))
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 1)
+	api.AssertNumberOfCalls(t, "PostMessage", 2)
+}
+
+func TestInstantMessenger_SendMessage_OpenIMChannelError(t *testing.T) {
+	user := slack.User{ID: "123", Name: "user1"}
+	message := slack.Message{Text: "text message"}
+
+	api := new(messageSenderMock)
+	api.On("OpenIMChannel", user).Return("", errors.New("open_im_error"))
+
+	im := slack.NewInstantMessenger(api)
+	assert.Error(t, im.SendMessage(user, message))
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 1)
+
+	assert.Error(t, im.SendMessage(user, message))
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 2)
+}
+
+func TestInstantMessenger_SendMessage_PostMessageError(t *testing.T) {
+	user := slack.User{ID: "123", Name: "user1"}
+	message := slack.Message{Text: "text message"}
+
+	api := new(messageSenderMock)
+	api.On("OpenIMChannel", user).Return("channel1", nil)
+	api.On("PostMessage", "channel1", message).Return(errors.New("post_message_error"))
+
+	im := slack.NewInstantMessenger(api)
+	assert.Error(t, im.SendMessage(user, message))
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 1)
+	api.AssertNumberOfCalls(t, "PostMessage", 1)
+
+	assert.Error(t, im.SendMessage(user, message))
+	api.AssertNumberOfCalls(t, "OpenIMChannel", 1)
+	api.AssertNumberOfCalls(t, "PostMessage", 2)
+}
+
+type messageSenderMock struct {
+	mock.Mock
+}
+
+func (m *messageSenderMock) OpenIMChannel(user slack.User) (string, error) {
+	args := m.Called(user)
+
+	return args.String(0), args.Error(1)
+}
+
+func (m *messageSenderMock) PostMessage(channelID string, message slack.Message) error {
+	return m.Called(channelID, message).Error(0)
+}

--- a/slack/message.go
+++ b/slack/message.go
@@ -1,0 +1,6 @@
+package slack
+
+type Message struct {
+	Text        string       `json:"text"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+}

--- a/slack/response.go
+++ b/slack/response.go
@@ -1,21 +1,20 @@
 package slack
 
 type Response struct {
+	Message
 	ResponseType responseType `json:"response_type,omitempty"`
-	Text         string       `json:"text"`
-	Attachments  []Attachment `json:"attachments,omitempty"`
 }
 
 func NewEphemeralResponse(text string) *Response {
 	return &Response{
 		ResponseType: ResponseTypeEphemeral,
-		Text:         text,
+		Message:      Message{Text: text},
 	}
 }
 
 func NewInChannelResponse(text string) *Response {
 	return &Response{
 		ResponseType: ResponseTypeInChannel,
-		Text:         text,
+		Message:      Message{Text: text},
 	}
 }

--- a/slack/team_directory.go
+++ b/slack/team_directory.go
@@ -1,0 +1,55 @@
+package slack
+
+import (
+	"fmt"
+	"sync"
+)
+
+type userLister interface {
+	ListUsers() ([]User, error)
+}
+
+type TeamDirectory struct {
+	api userLister
+
+	mu    sync.RWMutex
+	cache map[string]User
+}
+
+func NewTeamDirectory(api userLister) *TeamDirectory {
+	return &TeamDirectory{api: api, cache: make(map[string]User)}
+}
+
+func (dir *TeamDirectory) Fetch(username string) (User, error) {
+	dir.mu.RLock()
+	user, ok := dir.cache[username]
+	dir.mu.RUnlock()
+
+	if ok {
+		return user, nil
+	}
+
+	dir.mu.Lock()
+	defer dir.mu.Unlock()
+
+	user, ok = dir.cache[username]
+	if !ok {
+		users, err := dir.api.ListUsers()
+		if err != nil {
+			return User{}, fmt.Errorf("failed to fetch team users: %s", err)
+		}
+
+		dir.cache = make(map[string]User, len(users))
+		for _, user := range users {
+			dir.cache[user.Name] = user
+		}
+
+		user, ok = dir.cache[username]
+	}
+
+	if !ok {
+		return User{}, NoSuchUserError{Name: username}
+	}
+
+	return user, nil
+}

--- a/slack/team_directory_test.go
+++ b/slack/team_directory_test.go
@@ -1,0 +1,78 @@
+package slack_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/andrewslotin/michael/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTeamDirectory_Fetch_ExistingUser(t *testing.T) {
+	team := []slack.User{
+		{ID: "U1", Name: "user1"},
+		{ID: "U2", Name: "user2"},
+		{ID: "U3", Name: "user3"},
+	}
+
+	api := new(apiMock)
+	api.On("ListUsers").Return(team, nil)
+
+	users := slack.NewTeamDirectory(api)
+
+	for _, member := range team {
+		user, err := users.Fetch(member.Name)
+		if assert.NoError(t, err) {
+			assert.Equal(t, member, user)
+		}
+	}
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "ListUsers", 1)
+}
+
+func TestTeamDirectory_Fetch_NonExistingUser(t *testing.T) {
+	team := []slack.User{
+		{ID: "U1", Name: "user1"},
+	}
+
+	api := new(apiMock)
+	api.On("ListUsers").Return(team, nil)
+
+	users := slack.NewTeamDirectory(api)
+
+	_, err := users.Fetch("user2")
+	assert.IsType(t, slack.NoSuchUserError{}, err)
+	assert.EqualError(t, err, "there is no user with username 'user2' in the team")
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "ListUsers", 1)
+}
+
+func TestTeamDirectory_Fetch_WebAPIError(t *testing.T) {
+	api := new(apiMock)
+	api.On("ListUsers").Return(nil, errors.New("Slack Web API has returned an error"))
+
+	users := slack.NewTeamDirectory(api)
+
+	_, err := users.Fetch("user1")
+	assert.EqualError(t, err, "failed to fetch team users: Slack Web API has returned an error")
+
+	api.AssertExpectations(t)
+	api.AssertNumberOfCalls(t, "ListUsers", 1)
+}
+
+type apiMock struct {
+	mock.Mock
+}
+
+func (m *apiMock) ListUsers() ([]slack.User, error) {
+	args := m.Called()
+
+	if err := args.Error(1); err != nil {
+		return nil, err
+	}
+
+	return args.Get(0).([]slack.User), nil
+}

--- a/slack/webapi.go
+++ b/slack/webapi.go
@@ -76,6 +76,24 @@ func (api *WebAPI) GetChannelTopic(channelID string) (string, error) {
 	return v.Channel.Topic.Value, nil
 }
 
+func (api *WebAPI) ListUsers() ([]User, error) {
+	const method = "users.list"
+
+	resp, requestURL, err := api.Call(method, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var v struct {
+		Members []User `json:"members"`
+	}
+	if err := json.Unmarshal(resp, &v); err != nil {
+		return nil, wrapError(fmt.Errorf("failed to decode response body %q (%s)", resp, err), method, requestURL)
+	}
+
+	return v.Members, nil
+}
+
 func (api *WebAPI) Call(method string, params url.Values) (response []byte, u *url.URL, err error) {
 	req, err := http.NewRequest("GET", api.BaseURL+"/"+method, nil)
 	if err != nil {

--- a/slack/webapi.go
+++ b/slack/webapi.go
@@ -94,6 +94,30 @@ func (api *WebAPI) ListUsers() ([]User, error) {
 	return v.Members, nil
 }
 
+func (api *WebAPI) PostMessage(channelID string, message Message) error {
+	const method = "chat.postMessage"
+
+	params := url.Values{}
+	params.Set("channel", channelID)
+	params.Set("text", message.Text)
+
+	if len(message.Attachments) > 0 {
+		attachments, err := json.Marshal(message.Attachments)
+		if err != nil {
+			return fmt.Errorf("failed to encode attachments for message %s: %s", message.Text, err)
+		}
+
+		params.Set("attachments", string(attachments))
+	}
+
+	_, requestURL, err := api.Call(method, params)
+	if err != nil {
+		return wrapError(fmt.Errorf("failed to post message %v to channel %s: %s", message, channelID, err), method, requestURL)
+	}
+
+	return nil
+}
+
 func (api *WebAPI) Call(method string, params url.Values) (response []byte, u *url.URL, err error) {
 	req, err := http.NewRequest("GET", api.BaseURL+"/"+method, nil)
 	if err != nil {

--- a/slack/webapi.go
+++ b/slack/webapi.go
@@ -118,6 +118,29 @@ func (api *WebAPI) PostMessage(channelID string, message Message) error {
 	return nil
 }
 
+func (api *WebAPI) OpenIMChannel(user User) (string, error) {
+	const method = "im.open"
+
+	params := url.Values{}
+	params.Set("user", user.ID)
+
+	resp, requestURL, err := api.Call(method, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to open an IM message with %s: %s", user, err)
+	}
+
+	var v struct {
+		Channel struct {
+			ID string `json:"id"`
+		} `json:"channel"`
+	}
+	if err := json.Unmarshal(resp, &v); err != nil {
+		return "", wrapError(fmt.Errorf("failed to decode response body %q (%s)", resp, err), method, requestURL)
+	}
+
+	return v.Channel.ID, nil
+}
+
 func (api *WebAPI) Call(method string, params url.Values) (response []byte, u *url.URL, err error) {
 	req, err := http.NewRequest("GET", api.BaseURL+"/"+method, nil)
 	if err != nil {


### PR DESCRIPTION
Adds support for user references in deploy subjects. Referenced users will be notified via direct message once the deploy is done.