### PR TITLE
Don't test against go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.6.3
   - 1.7.4
   - 1.8rc1
   - tip


### PR DESCRIPTION
Go 1.8 is coming! While the code itself should still compile under go 1.6, the tests are not guaranteed to pass.